### PR TITLE
useContextを実装した

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useContext } from "react";
 import "./App.css";
-import js from "@eslint/js";
+import ApplemanContext from "./main";
 
 function App() {
   const [count, setCount] = useState(0);
+  const applemanInfo = useContext(ApplemanContext);
 
   const handleClick = () => {
     setCount(count + 1);
@@ -18,6 +19,11 @@ function App() {
       <h1>useState, useEffect</h1>
       <button onClick={handleClick}>+</button>
       <p>{count}</p>
+
+      <hr />
+      <h1>useContext</h1>
+      <p>{applemanInfo.name}</p>
+      <p>{applemanInfo.age}</p>
     </div>
   );
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,21 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.jsx'
+import { createContext, StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./index.css";
+import App from "./App.jsx";
 
-createRoot(document.getElementById('root')).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-)
+const applemanInfo = {
+  name: "appleman",
+  age: 24,
+};
+
+const ApplemanContext = createContext(applemanInfo);
+
+createRoot(document.getElementById("root")).render(
+  <ApplemanContext.Provider value={applemanInfo}>
+    <StrictMode>
+      <App />
+    </StrictMode>
+  </ApplemanContext.Provider>
+);
+
+export default ApplemanContext;


### PR DESCRIPTION
## 変更点

useContextを実装した

---

## なぜ必要なのか

props、データのバケツリレーを回避し可読性、保守性、再利用性を向上させるため。

---

## 使用例

`sreateContext`関数をReactライブラリからインポート
import { createContext } from "react";

propsを作成
```
const applemanInfo = {
  name: "appleman",
  age: 24,
};
```

オブジェクトを格納するための「コンテキスト」を作成
`const ApplemanContext = createContext(applemanInfo);`

エクスポート
`export default ApplemanContext;`

`useContext`関数をReactライブラリからインポート
`import { useContext } from "react";`

インポート
`import ApplemanContext from "./main";`

コンテキストの値を受け取る
`const applemanInfo = useContext(ApplemanContext);`

値を表示
```
<p>{applemanInfo.name}</p>
<p>{applemanInfo.age}</p>
```

---

## 関連するissue

Close #4 