### PR TITLE
useRefを実装した

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,11 @@
-import { useEffect, useState, useContext } from "react";
+import { useEffect, useState, useContext, useRef } from "react";
 import "./App.css";
 import ApplemanContext from "./main";
 
 function App() {
   const [count, setCount] = useState(0);
   const applemanInfo = useContext(ApplemanContext);
+  const ref = useRef();
 
   const handleClick = () => {
     setCount(count + 1);
@@ -13,6 +14,11 @@ function App() {
   useEffect(() => {
     console.log("Hello Hooks");
   }, [count]);
+
+  const handleRef = () => {
+    console.log(ref.current.value);
+    console.log(ref.current.offsetHeight);
+  };
 
   return (
     <div className="App">
@@ -24,6 +30,11 @@ function App() {
       <h1>useContext</h1>
       <p>{applemanInfo.name}</p>
       <p>{applemanInfo.age}</p>
+
+      <hr />
+      <h1>useRef</h1>
+      <input type="text" ref={ref} />
+      <button onClick={handleRef}>UseRef</button>
     </div>
   );
 }


### PR DESCRIPTION
## 変更点

useRefを実装した

---

## どのような場面で使うか

propsやstateを介さずに、直接 DOM 要素を参照・操作したい場合

---

## 使用例

`useRef`関数をReactライブラリからインポート
`import { useRef } from "react";`

`useRef`を宣言
`const ref = useRef();`

関数を宣言
```
const handleRef = () => {
    console.log(ref.current.value);
    console.log(ref.current.offsetHeight);
};
```

<input> 要素への参照を取得
`<input type="text" ref={ref} />`

押されたときに関数が走るボタン
`<button onClick={handleRef}>UseRef</button>`

つぎのような結果が得られる
<img width="294" height="165" alt="image" src="https://github.com/user-attachments/assets/8a28930c-dfcc-4a4f-98f4-bb87d9a9d3cb" />
<img width="320" height="70" alt="image" src="https://github.com/user-attachments/assets/44fb8121-eaf9-4558-aedd-c3b87e1beeec" />

---

## 関連するissue

Close #5 