### PR TITLE
useCallBackを実装した

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,9 +5,11 @@ import {
   useRef,
   useReducer,
   useMemo,
+  useCallback,
 } from "react"; // 関数をReactライブラリからインポート
 import "./App.css";
 import ApplemanContext from "./main"; // main.jsxからコンテンツをインポート
+import SomeChild from "./SomeChild";
 
 // useReducerを定義する
 const reducer = (state, action) => {
@@ -64,6 +66,17 @@ function App() {
     return count02 * count02;
   }, [count02]);
 
+  // useCallBack 関数のメモ化
+  const [counter, setCounter] = useState(0);
+
+  // const showCount = () => {
+  //   alert(`これは重い処理です。`);
+  // };
+
+  const showCount = useCallback(() => {
+    alert(`これは重い処理です。`);
+  }, [counter]);
+
   return (
     <div className="App">
       <h1>useState, useEffect</h1>
@@ -93,8 +106,13 @@ function App() {
       <div>結果{square}</div>
       <button onClick={() => setCount01(count01 + 1)}>+</button>
       <button onClick={() => setCount02(count02 + 1)}>+</button>
+
+      <hr />
+      <h1>useCallBack</h1>
+      <SomeChild showCount={showCount} />
     </div>
   );
 }
 
 export default App;
+z;

--- a/src/SomeChild.jsx
+++ b/src/SomeChild.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const SomeChild = () => {
+  return <div>SomeChild</div>;
+};
+
+export default SomeChild;


### PR DESCRIPTION
## 変更点

useCallBackを実装した

---

## どのような場面で使うか

`useMemo`と同様にパフォーマンスの最適化を目的として使用され、特に子コンポーネントに渡す関数をメモ化（キャッシュ）することで、不要な再レンダリングを防ぐために使う

---

## 使用例

`useCallBack`関数をReactライブラリからインポート
`import { useCallback, } from "react";`

`useCallBack`で使う`useState`を宣言
`const [counter, setCounter] = useState(0);`

`useCallBack`で関数をメモ化
```
const showCount = useCallback(() => 
    alert(`これは重い処理です。`);
}, [counter]);
```

子コンポーネントを宣言
```
import React from "react";

const SomeChild = () => {
  return <div>SomeChild</div>;
};

export default SomeChild;
```

子コンポーネント呼び出し
`<SomeChild showCount={showCount} />`

---

## 関連するissue

Close #8 
- #8 
